### PR TITLE
use SPARQL query to generate the answer in the dictionary

### DIFF
--- a/triplesdb/generate_template.py
+++ b/triplesdb/generate_template.py
@@ -306,9 +306,18 @@ ASK {
 
         self.templates['template_dimreg_4var_yn_answer'] = t4
 
+        # create a template number dictionary
+        # key is template_name, value is number
+        self.template_number = {tmplt: i+1 for i, tmplt in enumerate(sorted(self.templates.keys()))}
+
     def template_names(self) -> list:
         """template names"""
         return self.templates.keys()
+
+    @property
+    def template_number_dict(self) -> dict:
+        return self.template_number
+
 
     # NOTE: The dictionary was a design decision to allow extension
     # to add other variables.
@@ -380,7 +389,7 @@ ASK {
                 varibs['unit_text'] = UNITS_SYMBOL[unit_symbol]  # = "feet"
 
             result = {'sparql': sparl_template.substitute(varibs),
-                      # 'template_name': template_name,  # This could be added here
+                      'template_name': template_name,
                       'variables': varibs,
                      }
 


### PR DESCRIPTION
This modifies the generate_template.py to execute the SPARQL query to generate the answers.  The answers are in the 'answer' key either as types bool or list.  The program runs in less than 2 seconds.

There are a few typo corrections here and there.

Commit 750dc5e:
This commit adds template_name to the outputted dictionary.  A couple helper functions based on that.